### PR TITLE
fix: set cascades to relations

### DIFF
--- a/src/main/java/fr/openobservatory/backend/entities/CelestialBodyEntity.java
+++ b/src/main/java/fr/openobservatory/backend/entities/CelestialBodyEntity.java
@@ -3,7 +3,6 @@ package fr.openobservatory.backend.entities;
 import jakarta.persistence.*;
 import java.util.Objects;
 import java.util.Set;
-
 import lombok.Data;
 
 @Data

--- a/src/main/java/fr/openobservatory/backend/entities/CelestialBodyEntity.java
+++ b/src/main/java/fr/openobservatory/backend/entities/CelestialBodyEntity.java
@@ -2,6 +2,8 @@ package fr.openobservatory.backend.entities;
 
 import jakarta.persistence.*;
 import java.util.Objects;
+import java.util.Set;
+
 import lombok.Data;
 
 @Data
@@ -21,6 +23,11 @@ public class CelestialBodyEntity {
 
   @Column(columnDefinition = "INTEGER", nullable = false)
   private Integer validityTime;
+
+  // ---
+
+  @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "celestialBody")
+  private Set<ObservationEntity> observations;
 
   // ---
 

--- a/src/main/java/fr/openobservatory/backend/entities/ObservationEntity.java
+++ b/src/main/java/fr/openobservatory/backend/entities/ObservationEntity.java
@@ -38,11 +38,13 @@ public class ObservationEntity {
   @Column(columnDefinition = "SMALLINT", nullable = false)
   private Visibility visibility;
 
-  @OneToMany(mappedBy = "observation")
-  private Set<ObservationVoteEntity> votes;
-
   @Column(columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
   private Instant createdAt;
+
+  // ---
+
+  @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "observation")
+  private Set<ObservationVoteEntity> votes;
 
   // ---
 

--- a/src/main/java/fr/openobservatory/backend/entities/UserEntity.java
+++ b/src/main/java/fr/openobservatory/backend/entities/UserEntity.java
@@ -2,6 +2,8 @@ package fr.openobservatory.backend.entities;
 
 import jakarta.persistence.*;
 import java.time.Instant;
+import java.util.Set;
+
 import lombok.Data;
 
 @Data
@@ -37,6 +39,11 @@ public class UserEntity {
 
   @Column(columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
   private Instant createdAt;
+
+  // ---
+
+  @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "author")
+  private Set<ObservationEntity> observations;
 
   // ---
 

--- a/src/main/java/fr/openobservatory/backend/entities/UserEntity.java
+++ b/src/main/java/fr/openobservatory/backend/entities/UserEntity.java
@@ -3,7 +3,6 @@ package fr.openobservatory.backend.entities;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Set;
-
 import lombok.Data;
 
 @Data


### PR DESCRIPTION
So, for instance, deleting a celestial body that has observations linked to it won't produce an error.