### PR TITLE
refactor: use Jakarta Validation to validate in services

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation=true

--- a/src/main/java/fr/openobservatory/backend/controllers/CelestialBodyController.java
+++ b/src/main/java/fr/openobservatory/backend/controllers/CelestialBodyController.java
@@ -6,7 +6,6 @@ import fr.openobservatory.backend.dto.SearchDto;
 import fr.openobservatory.backend.dto.SearchResultsDto;
 import fr.openobservatory.backend.dto.UpdateCelestialBodyDto;
 import fr.openobservatory.backend.services.CelestialBodyService;
-import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +37,7 @@ public class CelestialBodyController {
 
   @PostMapping
   @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
-  public ResponseEntity<CelestialBodyDto> create(@RequestBody @Valid CreateCelestialBodyDto dto) {
+  public ResponseEntity<CelestialBodyDto> create(@RequestBody CreateCelestialBodyDto dto) {
     var celestialBody = celestialBodyService.create(dto);
     return ResponseEntity.created(URI.create("/celestial-bodies/" + celestialBody.getId()))
         .body(celestialBody);
@@ -47,7 +46,7 @@ public class CelestialBodyController {
   @PatchMapping("/{id}")
   @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
   public ResponseEntity<CelestialBodyDto> update(
-      @PathVariable Long id, @RequestBody @Valid UpdateCelestialBodyDto dto) {
+      @PathVariable Long id, @RequestBody UpdateCelestialBodyDto dto) {
     var celestialBody = celestialBodyService.update(id, dto);
     return ResponseEntity.ok(celestialBody);
   }

--- a/src/main/java/fr/openobservatory/backend/controllers/CelestialBodyController.java
+++ b/src/main/java/fr/openobservatory/backend/controllers/CelestialBodyController.java
@@ -2,6 +2,7 @@ package fr.openobservatory.backend.controllers;
 
 import fr.openobservatory.backend.dto.CelestialBodyDto;
 import fr.openobservatory.backend.dto.CreateCelestialBodyDto;
+import fr.openobservatory.backend.dto.SearchDto;
 import fr.openobservatory.backend.dto.SearchResultsDto;
 import fr.openobservatory.backend.dto.UpdateCelestialBodyDto;
 import fr.openobservatory.backend.services.CelestialBodyService;
@@ -23,10 +24,8 @@ public class CelestialBodyController {
 
   @GetMapping
   @PreAuthorize("isAuthenticated()")
-  public ResponseEntity<SearchResultsDto<CelestialBodyDto>> search(
-      @RequestParam(required = false, defaultValue = "10") Integer limit,
-      @RequestParam(required = false, defaultValue = "0") Integer page) {
-    var celestialBodies = celestialBodyService.search(page, limit);
+  public ResponseEntity<SearchResultsDto<CelestialBodyDto>> search(SearchDto dto) {
+    var celestialBodies = celestialBodyService.search(dto);
     return ResponseEntity.ok(celestialBodies);
   }
 

--- a/src/main/java/fr/openobservatory/backend/controllers/ValidationControllerAdvice.java
+++ b/src/main/java/fr/openobservatory/backend/controllers/ValidationControllerAdvice.java
@@ -1,0 +1,19 @@
+package fr.openobservatory.backend.controllers;
+
+import fr.openobservatory.backend.exceptions.ValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ValidationControllerAdvice {
+
+  @ExceptionHandler(ValidationException.class)
+  public ProblemDetail validationException(ValidationException exception) {
+    var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
+    problem.setTitle("VALIDATION_ERROR");
+    problem.setProperty("violations", exception.getViolations());
+    return problem;
+  }
+}

--- a/src/main/java/fr/openobservatory/backend/dto/SearchDto.java
+++ b/src/main/java/fr/openobservatory/backend/dto/SearchDto.java
@@ -1,0 +1,18 @@
+package fr.openobservatory.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SearchDto {
+
+  @Range(message = "itemsPerPage.range", min = 1, max = 100)
+  private Integer itemsPerPage = 10;
+
+  @Range(message = "page.range", min = 0)
+  private Integer page = 0;
+}

--- a/src/main/java/fr/openobservatory/backend/dto/UpdateCelestialBodyDto.java
+++ b/src/main/java/fr/openobservatory/backend/dto/UpdateCelestialBodyDto.java
@@ -3,10 +3,12 @@ package fr.openobservatory.backend.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.hibernate.validator.constraints.Range;
 import org.openapitools.jackson.nullable.JsonNullable;
 
+@AllArgsConstructor
 @Data
 public class UpdateCelestialBodyDto {
 

--- a/src/main/java/fr/openobservatory/backend/dto/UpdateCelestialBodyDto.java
+++ b/src/main/java/fr/openobservatory/backend/dto/UpdateCelestialBodyDto.java
@@ -10,10 +10,9 @@ import org.openapitools.jackson.nullable.JsonNullable;
 @Data
 public class UpdateCelestialBodyDto {
 
-  private JsonNullable<@NotBlank @Size(min = 4, max = 64) String> name = JsonNullable.undefined();
+  private JsonNullable<@NotBlank @Size(min = 4, max = 64) String> name;
 
-  private JsonNullable<@NotNull @Range(min = 1, max = 12) Integer> validityTime =
-      JsonNullable.undefined();
+  private JsonNullable<@NotNull @Range(min = 1, max = 12) Integer> validityTime;
 
-  private JsonNullable<String> image = JsonNullable.undefined();
+  private JsonNullable<@NotNull String> image;
 }

--- a/src/main/java/fr/openobservatory/backend/exceptions/InvalidCelestialBodyNameException.java
+++ b/src/main/java/fr/openobservatory/backend/exceptions/InvalidCelestialBodyNameException.java
@@ -1,7 +1,0 @@
-package fr.openobservatory.backend.exceptions;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "INVALID_CELESTIAL_BODY_NAME")
-public class InvalidCelestialBodyNameException extends RuntimeException {}

--- a/src/main/java/fr/openobservatory/backend/exceptions/InvalidCelestialBodyValidityTimeException.java
+++ b/src/main/java/fr/openobservatory/backend/exceptions/InvalidCelestialBodyValidityTimeException.java
@@ -1,7 +1,0 @@
-package fr.openobservatory.backend.exceptions;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "INVALID_CELESTIAL_BODY_VALIDITY_TIME")
-public class InvalidCelestialBodyValidityTimeException extends RuntimeException {}

--- a/src/main/java/fr/openobservatory/backend/exceptions/ValidationException.java
+++ b/src/main/java/fr/openobservatory/backend/exceptions/ValidationException.java
@@ -1,0 +1,19 @@
+package fr.openobservatory.backend.exceptions;
+
+import jakarta.validation.ConstraintViolation;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class ValidationException extends RuntimeException {
+
+  private final Set<String> violations;
+
+  public <T> ValidationException(Set<ConstraintViolation<T>> violations) {
+    super("One or more errors were encountered while validating the supplied payload.");
+    this.violations = Objects.requireNonNull(violations, "violations must not be null")
+        .stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/fr/openobservatory/backend/exceptions/ValidationException.java
+++ b/src/main/java/fr/openobservatory/backend/exceptions/ValidationException.java
@@ -13,7 +13,9 @@ public class ValidationException extends RuntimeException {
 
   public <T> ValidationException(Set<ConstraintViolation<T>> violations) {
     super("One or more errors were encountered while validating the supplied payload.");
-    this.violations = Objects.requireNonNull(violations, "violations must not be null")
-        .stream().map(ConstraintViolation::getMessage).collect(Collectors.toSet());
+    this.violations =
+        Objects.requireNonNull(violations, "violations must not be null").stream()
+            .map(ConstraintViolation::getMessage)
+            .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/fr/openobservatory/backend/services/CelestialBodyService.java
+++ b/src/main/java/fr/openobservatory/backend/services/CelestialBodyService.java
@@ -12,6 +12,7 @@ import jakarta.validation.Validator;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @AllArgsConstructor
@@ -51,10 +52,9 @@ public class CelestialBodyService {
     var violations = validator.validate(dto);
     if (!violations.isEmpty())
       throw new ValidationException(violations);
-    var pageable = PageRequest.of(dto.getPage(), dto.getItemsPerPage());
     return SearchResultsDto.from(
         celestialBodyRepository
-            .findAll(pageable)
+            .findAll(Pageable.ofSize(dto.getItemsPerPage()).withPage(dto.getPage()))
             .map(o -> modelMapper.map(o, CelestialBodyDto.class)));
   }
 

--- a/src/main/java/fr/openobservatory/backend/services/CelestialBodyService.java
+++ b/src/main/java/fr/openobservatory/backend/services/CelestialBodyService.java
@@ -11,7 +11,6 @@ import fr.openobservatory.backend.repositories.CelestialBodyRepository;
 import jakarta.validation.Validator;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -27,8 +26,7 @@ public class CelestialBodyService {
 
   public CelestialBodyDto create(CreateCelestialBodyDto dto) {
     var violations = validator.validate(dto);
-    if (!violations.isEmpty())
-      throw new ValidationException(violations);
+    if (!violations.isEmpty()) throw new ValidationException(violations);
     if (celestialBodyRepository.existsCelestialBodyByNameIgnoreCase(dto.getName()))
       throw new CelestialBodyNameAlreadyUsedException();
     var celestialBody = modelMapper.map(dto, CelestialBodyEntity.class);
@@ -36,8 +34,7 @@ public class CelestialBodyService {
   }
 
   public void delete(Long id) {
-    if (!celestialBodyRepository.existsById(id))
-      throw new UnknownCelestialBodyException();
+    if (!celestialBodyRepository.existsById(id)) throw new UnknownCelestialBodyException();
     celestialBodyRepository.deleteById(id);
   }
 
@@ -50,8 +47,7 @@ public class CelestialBodyService {
 
   public SearchResultsDto<CelestialBodyDto> search(SearchDto dto) {
     var violations = validator.validate(dto);
-    if (!violations.isEmpty())
-      throw new ValidationException(violations);
+    if (!violations.isEmpty()) throw new ValidationException(violations);
     return SearchResultsDto.from(
         celestialBodyRepository
             .findAll(Pageable.ofSize(dto.getItemsPerPage()).withPage(dto.getPage()))
@@ -60,8 +56,7 @@ public class CelestialBodyService {
 
   public CelestialBodyDto update(Long id, UpdateCelestialBodyDto dto) {
     var violations = validator.validate(dto);
-    if (!violations.isEmpty())
-      throw new ValidationException(violations);
+    if (!violations.isEmpty()) throw new ValidationException(violations);
     var celestialBody =
         celestialBodyRepository.findById(id).orElseThrow(UnknownCelestialBodyException::new);
     if (dto.getName().isPresent()) {
@@ -73,8 +68,7 @@ public class CelestialBodyService {
     }
     if (dto.getValidityTime().isPresent())
       celestialBody.setValidityTime(dto.getValidityTime().get());
-    if (dto.getImage().isPresent())
-      celestialBody.setImage(dto.getImage().get());
+    if (dto.getImage().isPresent()) celestialBody.setImage(dto.getImage().get());
     return modelMapper.map(celestialBodyRepository.save(celestialBody), CelestialBodyDto.class);
   }
 }

--- a/src/test/java/fr/openobservatory/backend/services/CelestialBodyServiceTest.java
+++ b/src/test/java/fr/openobservatory/backend/services/CelestialBodyServiceTest.java
@@ -3,6 +3,7 @@ package fr.openobservatory.backend.services;
 import static org.assertj.core.api.Assertions.*;
 
 import fr.openobservatory.backend.dto.CreateCelestialBodyDto;
+import fr.openobservatory.backend.dto.SearchDto;
 import fr.openobservatory.backend.dto.UpdateCelestialBodyDto;
 import fr.openobservatory.backend.entities.CelestialBodyEntity;
 import fr.openobservatory.backend.exceptions.*;
@@ -166,6 +167,7 @@ class CelestialBodyServiceTest {
     var image = "image";
     var validityTime = 5;
     var pageable = PageRequest.of(page, itemsPerPage);
+    var dto = new SearchDto(itemsPerPage, page);
     // When
     Mockito.when(celestialBodyRepository.findAll(Mockito.isA(PageRequest.class)))
         .thenAnswer(
@@ -178,7 +180,7 @@ class CelestialBodyServiceTest {
               var list = List.of(entity);
               return new PageImpl<>(list, pageable, 1);
             });
-    var searchDto = celestialBodyService.search(page, itemsPerPage);
+    var searchDto = celestialBodyService.search(dto);
     // Then
     assertThat(searchDto.getData()).isNotEmpty();
     assertThat(searchDto.getData().get(0).getId()).isEqualTo(id);
@@ -187,38 +189,13 @@ class CelestialBodyServiceTest {
     assertThat(searchDto.getData().get(0).getImage()).isEqualTo(image);
   }
 
-  @DisplayName("CelestialBodyService#search should fail with to low items per page")
+  @DisplayName("CelestialBodyService#search should fail with invalid dto")
   @Test
   void search_should_fail_with_to_low_items_per_page() {
     // Given
-    var page = 1;
-    var itemsPerPage = -1;
+    var dto = new SearchDto(420, -50);
     // When
-    ThrowableAssert.ThrowingCallable action = () -> celestialBodyService.search(page, itemsPerPage);
-    // Then
-    assertThatThrownBy(action).isInstanceOf(InvalidPaginationException.class);
-  }
-
-  @DisplayName("CelestialBodyService#search should fail with to high items per page")
-  @Test
-  void search_should_fail_with_to_high_items_per_page() {
-    // Given
-    var page = 1;
-    var itemsPerPage = 200;
-    // When
-    ThrowableAssert.ThrowingCallable action = () -> celestialBodyService.search(page, itemsPerPage);
-    // Then
-    assertThatThrownBy(action).isInstanceOf(InvalidPaginationException.class);
-  }
-
-  @DisplayName("CelestialBodyService#search should fail with below zero page number")
-  @Test
-  void search_should_fail_with_below_zero_page_number() {
-    // Given
-    var page = -1;
-    var itemsPerPage = 5;
-    // When
-    ThrowableAssert.ThrowingCallable action = () -> celestialBodyService.search(page, itemsPerPage);
+    ThrowableAssert.ThrowingCallable action = () -> celestialBodyService.search(dto);
     // Then
     assertThatThrownBy(action).isInstanceOf(InvalidPaginationException.class);
   }

--- a/src/test/java/fr/openobservatory/backend/services/CelestialBodyServiceTest.java
+++ b/src/test/java/fr/openobservatory/backend/services/CelestialBodyServiceTest.java
@@ -32,14 +32,13 @@ import org.springframework.data.domain.PageRequest;
 @ExtendWith(MockitoExtension.class)
 class CelestialBodyServiceTest {
 
-  @Mock private CelestialBodyRepository celestialBodyRepository;
+  @Mock CelestialBodyRepository celestialBodyRepository;
 
-  @Spy private ModelMapper modelMapper;
+  @Spy ModelMapper modelMapper = new ModelMapper();
 
-  @Spy
-  Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+  @Spy Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-  @InjectMocks private CelestialBodyService celestialBodyService;
+  @InjectMocks CelestialBodyService celestialBodyService;
 
   // --- CelestialBodyService#create
 
@@ -154,7 +153,8 @@ class CelestialBodyServiceTest {
               entity.setName(name);
               entity.setValidityTime(validityTime);
               entity.setImage(image);
-              return new PageImpl<>(List.of(entity), PageRequest.of(dto.getPage(), dto.getItemsPerPage()), 1);
+              return new PageImpl<>(
+                  List.of(entity), PageRequest.of(dto.getPage(), dto.getItemsPerPage()), 1);
             });
     var searchDto = celestialBodyService.search(dto);
 
@@ -189,7 +189,9 @@ class CelestialBodyServiceTest {
     var name = "Neptune";
     var validityTime = 5;
     var image = "base64:image";
-    var dto = new UpdateCelestialBodyDto(JsonNullable.of(name), JsonNullable.of(validityTime), JsonNullable.of(image));
+    var dto =
+        new UpdateCelestialBodyDto(
+            JsonNullable.of(name), JsonNullable.of(validityTime), JsonNullable.of(image));
 
     // When
     when(celestialBodyRepository.findById(id))
@@ -222,7 +224,9 @@ class CelestialBodyServiceTest {
     var newName = "Mars";
     var validityTime = 5;
     var image = "base64:image";
-    var dto = new UpdateCelestialBodyDto(JsonNullable.of(newName), JsonNullable.of(validityTime), JsonNullable.of(image));
+    var dto =
+        new UpdateCelestialBodyDto(
+            JsonNullable.of(newName), JsonNullable.of(validityTime), JsonNullable.of(image));
 
     // When
     when(celestialBodyRepository.findById(id))
@@ -254,7 +258,9 @@ class CelestialBodyServiceTest {
     var name = "Neptune";
     var validityTime = 5;
     var image = "base64:image";
-    var dto = new UpdateCelestialBodyDto(JsonNullable.undefined(), JsonNullable.undefined(), JsonNullable.undefined());
+    var dto =
+        new UpdateCelestialBodyDto(
+            JsonNullable.undefined(), JsonNullable.undefined(), JsonNullable.undefined());
 
     // When
     when(celestialBodyRepository.findById(id))
@@ -283,7 +289,9 @@ class CelestialBodyServiceTest {
   void update_should_throw_when_dto_is_invalid() {
     // Given
     var id = 2L;
-    var dto = new UpdateCelestialBodyDto(JsonNullable.of("A"), JsonNullable.of(-5), JsonNullable.of(null));
+    var dto =
+        new UpdateCelestialBodyDto(
+            JsonNullable.of("A"), JsonNullable.of(-5), JsonNullable.of(null));
 
     // When
     ThrowingCallable action = () -> celestialBodyService.update(id, dto);
@@ -297,7 +305,9 @@ class CelestialBodyServiceTest {
   void update_should_throw_when_id_is_unknown() {
     // Given
     var id = 2L;
-    var dto = new UpdateCelestialBodyDto(JsonNullable.undefined(), JsonNullable.undefined(), JsonNullable.undefined());
+    var dto =
+        new UpdateCelestialBodyDto(
+            JsonNullable.undefined(), JsonNullable.undefined(), JsonNullable.undefined());
 
     // When
     when(celestialBodyRepository.findById(id)).thenReturn(Optional.empty());
@@ -315,7 +325,9 @@ class CelestialBodyServiceTest {
     var name = "Neptune";
     var validityTime = 5;
     var image = "base64:image";
-    var dto = new UpdateCelestialBodyDto(JsonNullable.of("Mars"), JsonNullable.of(4), JsonNullable.of("base64:new_image"));
+    var dto =
+        new UpdateCelestialBodyDto(
+            JsonNullable.of("Mars"), JsonNullable.of(4), JsonNullable.of("base64:new_image"));
 
     // When
     when(celestialBodyRepository.findById(id))
@@ -328,7 +340,8 @@ class CelestialBodyServiceTest {
               entity.setValidityTime(validityTime);
               return Optional.of(entity);
             });
-    when(celestialBodyRepository.existsCelestialBodyByNameIgnoreCase(dto.getName().get())).thenReturn(true);
+    when(celestialBodyRepository.existsCelestialBodyByNameIgnoreCase(dto.getName().get()))
+        .thenReturn(true);
     ThrowingCallable action = () -> celestialBodyService.update(id, dto);
 
     // Then


### PR DESCRIPTION
Use Jakarta Validation API to validate DTOs in service layer : less branches to cover in unit tests and more flexibility for validation options.

- [x] CelestialBodyService
- [ ] ObservationService
- [ ] PushSubscriptionService
- [ ] UserService